### PR TITLE
Add support for numpy I/O (with pickle disabled)

### DIFF
--- a/DOCS.txt
+++ b/DOCS.txt
@@ -24,6 +24,14 @@ FUNCTIONS
         Returns (string):
             A base64-encoded data URL that you can easily send through the web
     
+    url_from_numpy(array, mime_type='application', mime_subtype='octet-stream', **kwargs)
+        Parameters:
+            array (np.array, required): A numpy array that will be converted to a data URL
+            **kwargs: Arguments passed to the np.save function
+        
+        Returns (string):
+            A base64-encoded data URL that you can easily send through the web
+    
     url_from_pandas(df, format='csv', mime_type=None, mime_subtype=None, **kwargs)
         Parameters:
             df (pd.DataFrame, required): A pandas dataframe that will be converted to a data URL
@@ -53,6 +61,14 @@ FUNCTIONS
         
         Returns (object):
             A python object was serialized through JSON (e.g. a dict, list, string)
+    
+    url_to_numpy(data_url, **kwargs)
+        Parameters:
+            data_url (string, required): A string that contains the base64-encoded array along with a MIME type header (starts with "data:")
+            **kwargs: Arguments passed to the np.load function
+        
+        Returns (np.array):
+            A numpy array that was previous saved by np.save
     
     url_to_pandas(data_url, format='csv', **kwargs)
         Parameters:

--- a/DOCS.txt
+++ b/DOCS.txt
@@ -24,9 +24,10 @@ FUNCTIONS
         Returns (string):
             A base64-encoded data URL that you can easily send through the web
     
-    url_from_numpy(array, mime_type='application', mime_subtype='octet-stream', **kwargs)
+    url_from_numpy(array, header=False, **kwargs)
         Parameters:
             array (np.array, required): A numpy array that will be converted to a data URL
+            header (bool, default=False): Whether to include a MIME type header in the URL
             **kwargs: Arguments passed to the np.save function
         
         Returns (string):
@@ -62,9 +63,10 @@ FUNCTIONS
         Returns (object):
             A python object was serialized through JSON (e.g. a dict, list, string)
     
-    url_to_numpy(data_url, **kwargs)
+    url_to_numpy(data_url, header=False, **kwargs)
         Parameters:
             data_url (string, required): A string that contains the base64-encoded array along with a MIME type header (starts with "data:")
+            header (bool, default=False): Whether there is a MIME type header included in the input `data_url`
             **kwargs: Arguments passed to the np.load function
         
         Returns (np.array):

--- a/README.md
+++ b/README.md
@@ -93,14 +93,22 @@ Note that if a `dict` key is an integer, it will be converted to string by `json
 
 ### Numpy
 
+By default, `numpy` arrays will not contain the mime header. However, you can enable it with `header=True` (e.g. if you want to upload/download a `npy` file).
+
 ```python
 import dash_io as dio
 
-# Encode/decode numpy arrays
+# Encode/decode numpy arrays without MIME header by default
 array = np.array([[1, 2, 3], [4, 5, 6]])
 encoded = dio.url_from_numpy(array)
 decoded = dio.url_to_numpy(encoded)
+
+# You can also use headers
+encoded = dio.url_from_numpy(array, header=True)
+decoded = dio.url_to_numpy(encoded, header=True)
 ```
+
+Note that pickling is disabled for `npy` files for security reasons.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ encoded = dio.url_from_json([1,2,3,4,5])
 Note that if a `dict` key is an integer, it will be converted to string by `json`. This is a normal behavior.
 
 
+### Numpy
+
+```python
+import dash_io as dio
+
+# Encode/decode numpy arrays
+array = np.array([[1, 2, 3], [4, 5, 6]])
+encoded = dio.url_from_numpy(array)
+decoded = dio.url_to_numpy(encoded)
+```
+
 ## Documentation
 
 You can access the documentation by calling:

--- a/dash_io/__init__.py
+++ b/dash_io/__init__.py
@@ -259,11 +259,12 @@ def url_to_json(data_url, **kwargs):
 
 
 def url_from_numpy(
-    array, mime_type="application", mime_subtype="octet-stream", **kwargs
+    array, header=False, **kwargs
 ):
     """
     Parameters:
         array (np.array, required): A numpy array that will be converted to a data URL
+        header (bool, default=False): Whether to include a MIME type header in the URL
         **kwargs: Arguments passed to the np.save function
 
     Returns (string):
@@ -281,13 +282,17 @@ def url_from_numpy(
 
     encoded = base64.b64encode(buffer_val).decode("utf-8")
 
-    return f"data:{mime_type}/{mime_subtype};base64,{encoded}"
+    if header is  True:
+        return f"data:application/octet-stream;base64,{encoded}"
+    else:
+        return encoded
 
 
-def url_to_numpy(data_url, **kwargs):
+def url_to_numpy(data_url, header=False, **kwargs):
     """
     Parameters:
         data_url (string, required): A string that contains the base64-encoded array along with a MIME type header (starts with "data:")
+        header (bool, default=False): Whether there is a MIME type header included in the input `data_url`
         **kwargs: Arguments passed to the np.load function
 
     Returns (np.array):
@@ -300,9 +305,12 @@ def url_to_numpy(data_url, **kwargs):
         )
 
     data_url = _validate_data_prefix(data_url)
-    header, data = data_url.split(",")
-    _validate_b64_header(header)
-
+    if header is True:
+        header, data = data_url.split(",")
+        _validate_b64_header(header)
+    else:
+        data = data_url
+    
     decoded = base64.b64decode(data)
 
     return np.load(BytesIO(decoded), allow_pickle=False, **kwargs)

--- a/dash_io/__init__.py
+++ b/dash_io/__init__.py
@@ -2,10 +2,10 @@ import base64
 import os
 import json
 from io import BytesIO, StringIO
-import pickle
 
 import pandas as pd
 from PIL import Image
+import numpy as np
 
 
 # Helper functions
@@ -256,3 +256,53 @@ def url_to_json(data_url, **kwargs):
     decoded = base64.b64decode(data)
 
     return json.loads(decoded, **kwargs)
+
+
+def url_from_numpy(
+    array, mime_type="application", mime_subtype="octet-stream", **kwargs
+):
+    """
+    Parameters:
+        array (np.array, required): A numpy array that will be converted to a data URL
+        **kwargs: Arguments passed to the np.save function
+
+    Returns (string):
+        A base64-encoded data URL that you can easily send through the web
+    """
+    if "allow_pickle" in kwargs:
+        raise ValueError(
+            "allow_pickle cannot be passed to url_from_numpy for security reasons."
+        )
+
+    buffer = BytesIO()
+    np.save(buffer, array, allow_pickle=False, **kwargs)
+
+    buffer_val = buffer.getvalue()
+
+    encoded = base64.b64encode(buffer_val).decode("utf-8")
+
+    return f"data:{mime_type}/{mime_subtype};base64,{encoded}"
+
+
+def url_to_numpy(data_url, **kwargs):
+    """
+    Parameters:
+        data_url (string, required): A string that contains the base64-encoded array along with a MIME type header (starts with "data:")
+        **kwargs: Arguments passed to the np.load function
+
+    Returns (np.array):
+        A numpy array that was previous saved by np.save
+    """
+
+    if "allow_pickle" in kwargs:
+        raise ValueError(
+            "allow_pickle is not supported for dio.url_to_numpy for security reasons."
+        )
+
+    data_url = _validate_data_prefix(data_url)
+    header, data = data_url.split(",")
+    _validate_b64_header(header)
+
+    decoded = base64.b64decode(data)
+
+    return np.load(BytesIO(decoded), allow_pickle=False, **kwargs)

--- a/dash_io/__init__.py
+++ b/dash_io/__init__.py
@@ -258,9 +258,7 @@ def url_to_json(data_url, **kwargs):
     return json.loads(decoded, **kwargs)
 
 
-def url_from_numpy(
-    array, header=False, **kwargs
-):
+def url_from_numpy(array, header=False, **kwargs):
     """
     Parameters:
         array (np.array, required): A numpy array that will be converted to a data URL
@@ -282,7 +280,7 @@ def url_from_numpy(
 
     encoded = base64.b64encode(buffer_val).decode("utf-8")
 
-    if header is  True:
+    if header is True:
         return f"data:application/octet-stream;base64,{encoded}"
     else:
         return encoded
@@ -310,7 +308,7 @@ def url_to_numpy(data_url, header=False, **kwargs):
         _validate_b64_header(header)
     else:
         data = data_url
-    
+
     decoded = base64.b64decode(data)
 
     return np.load(BytesIO(decoded), allow_pickle=False, **kwargs)

--- a/dash_io/__init__.py
+++ b/dash_io/__init__.py
@@ -302,8 +302,8 @@ def url_to_numpy(data_url, header=False, **kwargs):
             "allow_pickle is not supported for dio.url_to_numpy for security reasons."
         )
 
-    data_url = _validate_data_prefix(data_url)
     if header is True:
+        data_url = _validate_data_prefix(data_url)
         header, data = data_url.split(",")
         _validate_b64_header(header)
     else:

--- a/scripts/update_docs.py
+++ b/scripts/update_docs.py
@@ -1,0 +1,10 @@
+import pydoc
+
+import dash_io as dio
+
+
+generated = pydoc.render_doc(dio, renderer=pydoc.plaintext)
+generated = generated.split("\nFILE\n")[0].strip()
+
+with open("DOCS.txt", "w") as f:
+    f.write(generated)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="dash-io",
-    version="0.0.1.post1",
+    version="0.0.2.dev0",
     author="Plotly",
     author_email="xinghan@plot.ly",
     description="An API prototype for simplifying IO in Dash",

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -16,9 +16,14 @@ def test_array():
 def test_allow_pickle():
     with pytest.raises(ValueError):
         encoded = dio.url_from_numpy(array, allow_pickle=False)
-        encoded = dio.url_from_numpy(array, allow_pickle=True)
 
     with pytest.raises(ValueError):
-        encoded = dio.url_from_numpy(array)
+        encoded = dio.url_from_numpy(array, allow_pickle=True)
+
+    encoded = dio.url_from_numpy(array)
+
+    with pytest.raises(ValueError):
         decoded = dio.url_to_numpy(encoded, allow_pickle=False)
+
+    with pytest.raises(ValueError):
         decoded = dio.url_to_numpy(encoded, allow_pickle=True)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+import dash_io as dio
+
+array = np.array([[1, 2, 3], [4, 5, 6]])
+
+
+def test_array():
+    encoded = dio.url_from_numpy(array)
+    decoded = dio.url_to_numpy(encoded)
+
+    np.testing.assert_array_equal(array, decoded)
+
+
+def test_allow_pickle():
+    with pytest.raises(ValueError):
+        encoded = dio.url_from_numpy(array, allow_pickle=False)
+        encoded = dio.url_from_numpy(array, allow_pickle=True)
+
+    with pytest.raises(ValueError):
+        encoded = dio.url_from_numpy(array)
+        decoded = dio.url_to_numpy(encoded, allow_pickle=False)
+        decoded = dio.url_to_numpy(encoded, allow_pickle=True)


### PR DESCRIPTION
Since numpy allows for pickle to be disabled, I think it might be useful for I/O of numpy arrays.

This would be especially useful for usecases where the user wants to save a numpy array inside a `dcc.Store`, or that wants to download/upload `.npy` that can be shared between end users (e.g. it could contain the result of some computations done using a numpy-compatible library).